### PR TITLE
Refactor with SOLID operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+backend/logs/
+backend/output/
+package-lock.json
+frontend/package-lock.json
+backend/package-lock.json

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ displaying results)
 ├── backend/ # Node.js backend (Express server)
 │ ├── package.json # Backend dependencies (express, winston, etc.)
 │ ├── server.js # Express app initialization and routes
+│ ├── operations/ # Operation classes implementing unified interface
 │ ├── routes/ # (Optional) Express route modules
 │ │ └── operations.js # Route handler for operation requests (if
 separated)
@@ -66,7 +67,7 @@ A display area for step-by-step trace logs of code execution. This can be a scro
 updating as the backend returns them.
 An area to show the result of the operation – which could be a numeric result, a success message, or
 an image/visualization (for R plotting operations).
-Basic error handling in the UI (displaying error messages if the backend returns an error).
+Smooth animations are provided using GSAP, and a global error boundary ensures the UI continues to work even if a component throws.
 Example UI Flow: The user enters a number (or uses a default), clicks "Run Factorial". The app calls the
 backend API to execute the factorial operation. While waiting, it could show a loading indicator. When the
 response arrives, the UI shows the returned logs line by line (to illustrate the code execution flow) and the
@@ -208,6 +209,7 @@ app.use('/output', express.static(path.join(__dirname, 'output'))) will allow th
 frontend to request http://localhost:5000/output/plot_output.png and get the image.
 Backend Code (server.js):
 Below is a simplified version of the Express server ( backend/server.js ) highlighting the core
+Operations in the backend are implemented as classes extending a common Operation base and created through an OperationFactory.
 functionality:
 const path = require('path');
 const express = require('express');
@@ -619,25 +621,20 @@ Running the Project (Installation & Usage)
 To get started with this unified project, follow these steps:
 Prerequisites: Ensure you have Node.js (and npm) installed, as well as Python 3 and R installed on
 your system.
-Python is needed to run the Python scripts. (If the Python scripts use extra libraries like snoop ,
-install them via pip . For example, run pip install snoop or use
-pip install -r backend/scripts/python/requirements.txt if such a file is provided.)
+Python is needed to run the Python scripts. Extra libraries such as numpy and pandas
+are listed in backend/requirements.txt. Install them with
+pip install -r backend/requirements.txt (and any other packages like snoop if needed).
 R is needed to run the R scripts. Make sure to install the R packages used by the scripts. In our
 example, we need the ggplot2 package. You can install it by launching R and running
 install.packages("ggplot2") .
 Ensure the commands python and Rscript are available in your PATH (so that Node can call
 them).
+You will also need a running Redis server for the backend caching example.
 Install dependencies: In the project root, run:
 npm install
 This will install root devDependencies (like concurrently). Then run:
 npm run install-all
-5
-1.
-2.
-3.
-4.
-5.
-15
+This installs the backend packages (including Redis support) and the frontend packages such as React, axios, and GSAP for animations.
 This will install dependencies for both the backend and frontend sub-projects (it runs
 npm install in each). Alternatively, you can manually run npm install in frontend/ and
 npm install in backend/ if you prefer.

--- a/backend/helpers/parseOutput.js
+++ b/backend/helpers/parseOutput.js
@@ -1,0 +1,19 @@
+/**
+ * Parse script output lines, separating logs and result.
+ * The result is the last line if it's a number.
+ * @param {string} output
+ * @returns {{ logs: string[], result: number|null }}
+ */
+function parseOutput(output) {
+  if (!output) return { logs: [], result: null };
+  const lines = output.trim().split(/\r?\n/);
+  let result = null;
+  const last = lines[lines.length - 1];
+  if (/^-?\d+$/.test(last)) {
+    result = parseInt(last, 10);
+    lines.pop();
+  }
+  return { logs: lines, result };
+}
+
+module.exports = { parseOutput };

--- a/backend/helpers/runCommand.js
+++ b/backend/helpers/runCommand.js
@@ -1,0 +1,19 @@
+const { exec } = require('child_process');
+
+/**
+ * Execute a shell command and capture stdout/stderr.
+ * @param {string} cmd
+ * @returns {Promise<{ stdout: string, stderr: string }>}
+ */
+function runCommand(cmd) {
+  return new Promise((resolve, reject) => {
+    exec(cmd, (error, stdout, stderr) => {
+      if (error) {
+        return reject({ error, stdout, stderr });
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+module.exports = { runCommand };

--- a/backend/middlewares/errorHandler.js
+++ b/backend/middlewares/errorHandler.js
@@ -1,0 +1,4 @@
+module.exports = (logger) => (err, req, res, next) => {
+  logger.error(err.stack || err.message);
+  res.status(500).json({ success: false, error: 'Internal server error' });
+};

--- a/backend/middlewares/requestLogger.js
+++ b/backend/middlewares/requestLogger.js
@@ -1,0 +1,4 @@
+module.exports = (logger) => (req, res, next) => {
+  logger.info(`Request: ${req.method} ${req.url}`);
+  next();
+};

--- a/backend/operations/FactorialOperation.js
+++ b/backend/operations/FactorialOperation.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const Operation = require('./Operation');
+const { runCommand } = require('../helpers/runCommand');
+const { parseOutput } = require('../helpers/parseOutput');
+
+class FactorialOperation extends Operation {
+  constructor(logger, redisClient) {
+    super(logger, redisClient);
+    this.script = path.join(__dirname, '..', 'scripts', 'python', 'factorial_trace.py');
+  }
+
+  async run(param) {
+    const n = Number(param) || 0;
+    const { stdout } = await runCommand(`python "${this.script}" ${n}`);
+    const { logs, result } = parseOutput(stdout);
+    if (result !== null) {
+      await this.redisClient.set(`factorial:${n}`, result.toString());
+    }
+    return { logs, result };
+  }
+}
+
+module.exports = FactorialOperation;

--- a/backend/operations/Operation.js
+++ b/backend/operations/Operation.js
@@ -1,0 +1,12 @@
+class Operation {
+  constructor(logger, redisClient) {
+    this.logger = logger;
+    this.redisClient = redisClient;
+  }
+
+  async run(param) {
+    throw new Error('run() not implemented');
+  }
+}
+
+module.exports = Operation;

--- a/backend/operations/OperationFactory.js
+++ b/backend/operations/OperationFactory.js
@@ -1,0 +1,22 @@
+const FactorialOperation = require('./FactorialOperation');
+const PlotOperation = require('./PlotOperation');
+
+class OperationFactory {
+  constructor(logger, redisClient) {
+    this.logger = logger;
+    this.redisClient = redisClient;
+  }
+
+  create(op) {
+    switch (op) {
+      case 'factorial':
+        return new FactorialOperation(this.logger, this.redisClient);
+      case 'plot':
+        return new PlotOperation(this.logger, this.redisClient);
+      default:
+        return null;
+    }
+  }
+}
+
+module.exports = OperationFactory;

--- a/backend/operations/PlotOperation.js
+++ b/backend/operations/PlotOperation.js
@@ -1,0 +1,21 @@
+const path = require('path');
+const Operation = require('./Operation');
+const { runCommand } = require('../helpers/runCommand');
+const { parseOutput } = require('../helpers/parseOutput');
+
+class PlotOperation extends Operation {
+  constructor(logger, redisClient) {
+    super(logger, redisClient);
+    this.script = path.join(__dirname, '..', 'scripts', 'r', 'plot_data.R');
+  }
+
+  async run(param) {
+    const points = Number(param) || 0;
+    const { stdout } = await runCommand(`Rscript "${this.script}" ${points}`);
+    const { logs } = parseOutput(stdout);
+    await this.redisClient.set('lastPlotPoints', points.toString());
+    return { logs, plotUrl: '/output/plot_output.png' };
+  }
+}
+
+module.exports = PlotOperation;

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "start:dev": "nodemon server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.0",
+    "winston": "^3.8.0",
+    "redis": "^4.6.7"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+pandas

--- a/backend/scripts/python/factorial_trace.py
+++ b/backend/scripts/python/factorial_trace.py
@@ -1,0 +1,40 @@
+import sys
+import numpy as np
+import pandas as pd
+
+class Calculator:
+    """Base calculator class"""
+    def compute(self, n):
+        raise NotImplementedError
+
+class FactorialCalculator(Calculator):
+    """Compute factorial with trace output using numpy/pandas"""
+    def compute(self, n):
+        if n < 0:
+            raise ValueError(f"factorial of negative number ({n}) is undefined")
+        arr = np.arange(1, n + 1, dtype=int)
+        df = pd.DataFrame({'step': arr, 'partial': np.cumprod(arr)})
+        for _, row in df.iterrows():
+            print(f" Step {row.step}: -> {row.partial}")
+        result = int(df['partial'].iloc[-1]) if n > 0 else 1
+        print(f"Factorial of {n} is {result}")
+        return result
+
+def main():
+    try:
+        n = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+    except ValueError:
+        print("Error: invalid integer input.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Starting factorial computation for n={n}")
+    calc = FactorialCalculator()
+    try:
+        result = calc.compute(n)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(result)
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/r/plot_data.R
+++ b/backend/scripts/r/plot_data.R
@@ -1,0 +1,29 @@
+#!/usr/bin/env Rscript
+library(ggplot2)
+
+args <- commandArgs(trailingOnly = TRUE)
+n <- if (length(args) > 0) as.numeric(args[1]) else 0
+
+if (is.na(n)) {
+  write("Invalid numeric input for points.", stderr())
+  quit(status=1)
+}
+if (n <= 0) {
+  write("Please provide a positive number of points.", stderr())
+  quit(status=1)
+}
+
+data <- data.frame(x = 1:n, y = cumsum(rnorm(n)))
+write(sprintf("Generated data with %d points (first 5 shown):", n), stdout())
+print(head(data, 5))
+
+p <- ggplot(data, aes(x = x, y = y)) +
+  geom_line(color="steelblue") +
+  ggtitle(sprintf("Random Walk with %d points", n)) +
+  theme_minimal()
+
+output_path <- file.path(dirname(sys.frame(1)$ofile), "..", "output", "plot_output.png")
+
+ggsave(filename=output_path, plot=p, width=6, height=4)
+write(paste("Plot saved to", output_path), stdout())
+write("Plot generation completed.", stdout())

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,68 @@
+const path = require('path');
+const express = require('express');
+const winston = require('winston');
+const { createClient } = require('redis');
+
+const requestLogger = require('./middlewares/requestLogger');
+const errorHandler = require('./middlewares/errorHandler');
+const OperationFactory = require('./operations/OperationFactory');
+
+const app = express();
+app.use(express.json());
+
+// Configure Winston logger
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.simple(),
+  transports: [
+    new winston.transports.File({ filename: path.join(__dirname, 'logs', 'app.log') }),
+    new winston.transports.Console()
+  ]
+});
+
+// Redis client for caching results
+const redisClient = createClient();
+redisClient.on('error', err => logger.error(`Redis error: ${err.message}`));
+redisClient.connect().catch(err => logger.error(`Redis connect error: ${err.message}`));
+
+// Request logging middleware
+app.use(requestLogger(logger));
+
+// Serve static files from output directory
+app.use('/output', express.static(path.join(__dirname, 'output')));
+
+const factory = new OperationFactory(logger, redisClient);
+
+// API route to handle operation execution requests
+app.post('/api/run', async (req, res, next) => {
+  const { op, param } = req.body;
+  logger.info(`Received operation request: op=${op}, param=${param}`);
+
+  const operation = factory.create(op);
+  if (!operation) {
+    logger.warn(`Unknown operation requested: ${op}`);
+    return res.status(400).json({ success: false, error: 'Unknown operation', logs: [] });
+  }
+
+  try {
+    const result = await operation.run(param);
+    logger.info(`Operation ${op} completed`);
+    return res.json({ success: true, ...result });
+  } catch (err) {
+    logger.error(`Operation error: ${err.error ? err.error.message : err.message}`);
+    if (err.stdout) {
+      const { parseOutput } = require('./helpers/parseOutput');
+      const { logs } = parseOutput(err.stdout);
+      return res.json({ success: false, error: err.error.message, logs });
+    }
+    return next(err.error || err);
+  }
+});
+
+// Error handling middleware
+app.use(errorHandler(logger));
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => {
+  logger.info(`Server listening on port ${PORT}`);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "axios": "^1.6.2",
+    "gsap": "^3.12.2"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test"
+  },
+  "proxy": "http://localhost:5000"
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>DataPieMelt</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,79 @@
+import React, { useState, useRef, useEffect } from 'react';
+import axios from 'axios';
+import { gsap } from 'gsap';
+
+function App() {
+  const [number, setNumber] = useState(0);
+  const [points, setPoints] = useState(0);
+  const [logs, setLogs] = useState([]);
+  const [result, setResult] = useState(null);
+  const [plotUrl, setPlotUrl] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const resultRef = useRef(null);
+  const logRef = useRef(null);
+
+  const runOp = async (op, param) => {
+    setLogs([]);
+    setResult(null);
+    setPlotUrl(null);
+    setError(null);
+    setLoading(true);
+    try {
+      if (isNaN(param) || param === '') {
+        throw new Error('Please provide a valid number');
+      }
+      const { data } = await axios.post('/api/run', { op, param });
+      if (data.success) {
+        setLogs(data.logs || []);
+        setResult(data.result);
+        if (data.plotUrl) setPlotUrl(data.plotUrl);
+      } else {
+        setLogs(data.logs || []);
+        setError(data.error || 'Error');
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (resultRef.current) {
+      gsap.fromTo(resultRef.current, { opacity: 0 }, { opacity: 1, duration: 0.5 });
+    }
+  }, [result, plotUrl]);
+
+  useEffect(() => {
+    if (logRef.current) {
+      gsap.fromTo(logRef.current, { y: 20, opacity: 0 }, { y: 0, opacity: 1, duration: 0.3 });
+    }
+  }, [logs]);
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <h1>DataPieMelt Demo</h1>
+      <div>
+        <input type="number" value={number} onChange={e => setNumber(e.target.value)} />
+        <button onClick={() => runOp('factorial', number)}>Run Factorial</button>
+      </div>
+      <div>
+        <input type="number" value={points} onChange={e => setPoints(e.target.value)} />
+        <button onClick={() => runOp('plot', points)}>Generate Plot</button>
+      </div>
+      {loading && <p>Processing...</p>}
+      {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+      {result !== null && <p ref={resultRef}>Result: {result}</p>}
+      {plotUrl && (
+        <div ref={resultRef}>
+          <img src={plotUrl} alt="plot" />
+        </div>
+      )}
+      <pre ref={logRef}>{logs.join('\n')}</pre>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/ErrorBoundary.js
+++ b/frontend/src/ErrorBoundary.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <h2 style={{ color: 'red' }}>Something went wrong: {this.state.error.message}</h2>;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import ErrorBoundary from './ErrorBoundary';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fullstack-code-exec-demo",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "install-all": "npm install --prefix backend && npm install --prefix frontend",
+    "dev": "concurrently \"npm:dev-backend\" \"npm:dev-frontend\"",
+    "dev-backend": "npm run start:dev --prefix backend",
+    "dev-frontend": "npm start --prefix frontend"
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- introduce Operation base class and per-operation subclasses
- centralize operation creation through OperationFactory
- refactor server to use OperationFactory
- convert factorial Python script to use a calculator class
- document operations folder and factory in README
- add GSAP animations and React error boundary

## Testing
- `npm test --prefix frontend --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68513914378c8333b4a8fa3efe21f246